### PR TITLE
Fix host unknown argument bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@
 
 ```
 wait-for-it.sh host:port [-s] [-t timeout] [-- command args]
--h HOST | --host=HOST       Host or IP under test
--p PORT | --port=PORT       TCP port under test
-                            Alternatively, you specify the host and port as host:port
--s | --strict               Only execute subcommand if the test succeeds
--q | --quiet                Don't output any status messages
--t TIMEOUT | --timeout=TIMEOUT
-                            Timeout in seconds, zero for no timeout
--- COMMAND ARGS             Execute command with args after the test finishes
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -b | --busybox              Use busybox timeout command, i.e. timeout needs -t flag
+    -w | --wget                 Use wget command to check http endpoints
+    -c | --curl                 Use curl command to check http endpoints
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Do not output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
 ```
 
 ## Examples
@@ -23,6 +26,12 @@ $ ./wait-for-it.sh www.google.com:80 -- echo "google is up"
 wait-for-it.sh: waiting 15 seconds for www.google.com:80
 wait-for-it.sh: www.google.com:80 is available after 0 seconds
 google is up
+```
+
+With the default args, you are just checking at the TCP level.  If you wanted to check that google is up and responding with a successful HTTP status code, you could use the `--curl` or `--wget` switches (assumes the respective `curl` or `wget` command is available on your system).  :
+
+```
+./wait-for-it.sh --curl www.google.com:80 -- echo "google is up"
 ```
 
 You can set your own timeout with the `-t` or `--timeout=` option.  Setting the timeout value to 0 will disable the timeout:

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #   Use this script to test if a given TCP host/port are available
+# https://github.com/vishnubob/wait-for-it
 
 cmdname=$(basename $0)
 
@@ -13,8 +14,11 @@ Usage:
     -h HOST | --host=HOST       Host or IP under test
     -p PORT | --port=PORT       TCP port under test
                                 Alternatively, you specify the host and port as host:port
+    -b | --busybox              Use busybox timeout command, i.e. timeout needs -t flag
+    -w | --wget                 Use wget command to check http endpoints
+    -c | --curl                 Use curl command to check http endpoints
     -s | --strict               Only execute subcommand if the test succeeds
-    -q | --quiet                Don't output any status messages
+    -q | --quiet                Do not output any status messages
     -t TIMEOUT | --timeout=TIMEOUT
                                 Timeout in seconds, zero for no timeout
     -- COMMAND ARGS             Execute command with args after the test finishes
@@ -32,8 +36,19 @@ wait_for()
     start_ts=$(date +%s)
     while :
     do
-        (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
-        result=$?
+        if [[ $CURL -eq 1 ]]; then
+            curl --output /dev/null --silent --fail http://$HOST:$PORT >/dev/null 2>&1
+            result=$?
+        elif [[ $WGET -eq 1 ]]; then
+            wget http://$HOST:$PORT/ >/dev/null 2>&1
+            result=$?
+        elif [[ $ISBUSY -eq 1 ]]; then
+            nc -z $HOST $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
         if [[ $result -eq 0 ]]; then
             end_ts=$(date +%s)
             echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
@@ -44,14 +59,18 @@ wait_for()
     return $result
 }
 
+if hash timeout 2>/dev/null; then
+    # timeout command is available
+    : # noop, because I don't know how to reverse the conditional :(
+else
+    # no timeout, e.g. in osx.  Use perl alternative
+    function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
+fi
+
 wait_for_wrapper()
 {
     # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
-    if [[ $QUIET -eq 1 ]]; then
-        timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
-    else
-        timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
-    fi
+    timeout $BUSYTIMEFLAG $TIMEOUT $0 --child $CHILD_ARGS &
     PID=$!
     trap "kill -INT -$PID" INT
     wait $PID
@@ -63,6 +82,8 @@ wait_for_wrapper()
 }
 
 # process arguments
+BUSYTIMEFLAG=""
+CHILD_ARGS=""
 while [[ $# -gt 0 ]]
 do
     case "$1" in
@@ -70,50 +91,77 @@ do
         hostport=(${1//:/ })
         HOST=${hostport[0]}
         PORT=${hostport[1]}
+        CHILD_ARGS="$CHILD_ARGS $HOST:$PORT"
         shift 1
         ;;
         --child)
-        CHILD=1
+        CHILD=1 
+        CHILD_ARGS="$CHILD_ARGS --child"
         shift 1
         ;;
-        -q | --quiet)
+        -q|--quiet)
         QUIET=1
+        CHILD_ARGS="$CHILD_ARGS --quiet"
         shift 1
         ;;
-        -s | --strict)
+        -w|--wget)
+        WGET=1
+        CHILD_ARGS="$CHILD_ARGS --wget"
+        shift 1
+        ;;
+        -c|--curl)
+        CURL=1
+        CHILD_ARGS="$CHILD_ARGS --curl"
+        shift 1
+        ;;
+        -b|--busybox)
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+        CHILD_ARGS="$CHILD_ARGS --busybox"
+        shift 1
+        ;;
+        -s|--strict)
         STRICT=1
+        CHILD_ARGS="$CHILD_ARGS --strict"
         shift 1
         ;;
         -h)
         HOST="$2"
         if [[ $HOST == "" ]]; then break; fi
+        CHILD_ARGS="$CHILD_ARGS HOST=$HOST"
         shift 2
         ;;
         --host=*)
         HOST="${1#*=}"
+        CHILD_ARGS="$CHILD_ARGS HOST=$HOST"
         shift 1
         ;;
         -p)
         PORT="$2"
         if [[ $PORT == "" ]]; then break; fi
+        CHILD_ARGS="$CHILD_ARGS PORT=$PORT"
         shift 2
         ;;
         --port=*)
         PORT="${1#*=}"
+        CHILD_ARGS="$CHILD_ARGS PORT=$PORT"
         shift 1
         ;;
         -t)
         TIMEOUT="$2"
         if [[ $TIMEOUT == "" ]]; then break; fi
+        CHILD_ARGS="$CHILD_ARGS --timeout=$TIMEOUT"
         shift 2
         ;;
         --timeout=*)
         TIMEOUT="${1#*=}"
+        CHILD_ARGS="$CHILD_ARGS --timeout=$TIMEOUT"
         shift 1
         ;;
         --)
         shift
         CLI="$@"
+        CHILD_ARGS="$CHILD_ARGS -- $CLI"
         break
         ;;
         --help)
@@ -131,10 +179,13 @@ if [[ "$HOST" == "" || "$PORT" == "" ]]; then
     usage
 fi
 
-TIMEOUT=${TIMEOUT:-15}
+TIMEOUT=${TIMEOUT:-30}
 STRICT=${STRICT:-0}
 CHILD=${CHILD:-0}
 QUIET=${QUIET:-0}
+CURL=${CURL:-0}
+WGET=${WGET:-0}
+ISBUSY=${ISBUSY:-0}
 
 if [[ $CHILD -gt 0 ]]; then
     wait_for

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -179,7 +179,7 @@ if [[ "$HOST" == "" || "$PORT" == "" ]]; then
     usage
 fi
 
-TIMEOUT=${TIMEOUT:-30}
+TIMEOUT=${TIMEOUT:-15}
 STRICT=${STRICT:-0}
 CHILD=${CHILD:-0}
 QUIET=${QUIET:-0}

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -128,23 +128,23 @@ do
         -h)
         HOST="$2"
         if [[ $HOST == "" ]]; then break; fi
-        CHILD_ARGS="$CHILD_ARGS HOST=$HOST"
+        CHILD_ARGS="$CHILD_ARGS -h $HOST"
         shift 2
         ;;
         --host=*)
         HOST="${1#*=}"
-        CHILD_ARGS="$CHILD_ARGS HOST=$HOST"
+        CHILD_ARGS="$CHILD_ARGS -h $HOST"
         shift 1
         ;;
         -p)
         PORT="$2"
         if [[ $PORT == "" ]]; then break; fi
-        CHILD_ARGS="$CHILD_ARGS PORT=$PORT"
+        CHILD_ARGS="$CHILD_ARGS -p $PORT"
         shift 2
         ;;
         --port=*)
         PORT="${1#*=}"
-        CHILD_ARGS="$CHILD_ARGS PORT=$PORT"
+        CHILD_ARGS="$CHILD_ARGS -p $PORT"
         shift 1
         ;;
         -t)


### PR DESCRIPTION
Was getting an error `Unknown argument: HOST=db` from the arguments HOST and PORT not being recognized by the child command.